### PR TITLE
Updated model test to reflect changes in string output

### DIFF
--- a/app/models/payload_creator.rb
+++ b/app/models/payload_creator.rb
@@ -27,7 +27,6 @@ module PayloadCreator
     user_agent = UserAgent.parse(user_agent_info)
     user_agent_qualities[:browser] = user_agent.browser
     user_agent_qualities[:platform] = user_agent.platform
-    # We should decide what we need from the user agent and adjust our table to reflect that
     user_agent_qualities[:version] = "Windows 8.1"
     user_agent_qualities[:os] = user_agent.os
     user_agent_qualities

--- a/app/models/payload_request.rb
+++ b/app/models/payload_request.rb
@@ -1,5 +1,4 @@
 class PayloadRequest < ActiveRecord::Base
-
   belongs_to :event
   belongs_to :ip
   belongs_to :referred_by
@@ -14,7 +13,6 @@ class PayloadRequest < ActiveRecord::Base
   validates :responded_in, presence: true
   validates :referred_by_id, presence: true
   validates :request_type_id, presence: true
-  # validates :parameters, presence: true
   validates :event_id, presence: true
   validates :user_agent_info_id, presence: true
   validates :screen_size_id, presence: true

--- a/app/models/referred_by.rb
+++ b/app/models/referred_by.rb
@@ -2,5 +2,4 @@ class ReferredBy < ActiveRecord::Base
   has_many :payload_requests
 
   validates :name, presence: true
-
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -18,7 +18,7 @@ class EventTest < Minitest::Test
     event1 = Event.create({ name: "events!"})
     event2 = Event.create({ name: "events!"})
     event3 = Event.create({ name: "A-list events!"})
-    assert_equal ["events!", "A-list events!"], Event.list_events_by_frequency
 
+    assert_equal ["events!", "A-list events!"], Event.list_events_by_frequency
   end
 end

--- a/test/models/payload_request_test.rb
+++ b/test/models/payload_request_test.rb
@@ -1,11 +1,46 @@
 require_relative '../test_helper'
 
 class PayloadRequestTest < Minitest::Test
-
   include TestHelpers
 
   def test_payload_without_info_is_not_valid
     refute PayloadRequest.create(nil).valid?
+  end
+
+  def test_payload_without_url_is_not_valid
+    refute PayloadRequest.create({url_id: ""}).valid?
+  end
+
+  def test_payload_without_requested_at_is_not_valid
+    refute PayloadRequest.create({requested_at: ""}).valid?
+  end
+
+  def test_payload_without_responded_in_not_valid
+    refute PayloadRequest.create({responded_in: ""}).valid?
+  end
+
+  def test_payload_without_referred_by_is_not_valid
+    refute PayloadRequest.create({referred_by_id: ""}).valid?
+  end
+
+  def test_payload_without_request_type_is_not_valid
+    refute PayloadRequest.create({request_type_id: ""}).valid?
+  end
+
+  def test_payload_without_event_is_not_valid
+    refute PayloadRequest.create({event_id: ""}).valid?
+  end
+
+  def test_payload_without_user_agent_info_is_not_valid
+    refute PayloadRequest.create({user_agent_info_id: ""}).valid?
+  end
+
+  def test_payload_without_screen_size_is_not_valid
+    refute PayloadRequest.create({screen_size_id: ""}).valid?
+  end
+
+  def test_payload_without_ip_is_not_valid
+    refute PayloadRequest.create({ip_id: ""}).valid?
   end
 
   def test_it_validates_payload_request_with_values

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -20,7 +20,7 @@ class RequestTypeTest < Minitest::Test
     RequestType.create({ name: "POST"})
     RequestType.create({ name: "DELETE"})
 
-    assert_equal ["POST", "GET", "DELETE"], RequestType.all_http_verbs
+    assert_equal "POST, GET, DELETE", RequestType.all_http_verbs
   end
 
   def test_it_finds_most_common_request_type
@@ -28,7 +28,7 @@ class RequestTypeTest < Minitest::Test
     RequestType.create({name: "GET"})
     RequestType.create({name: "POST"})
 
-    assert_equal ["GET"], RequestType.most_frequent_request_type
+    assert_equal "GET", RequestType.most_frequent_request_type
   end
 
 end

--- a/test/models/screen_size_test.rb
+++ b/test/models/screen_size_test.rb
@@ -25,7 +25,7 @@ class ScreenSizeTest < Minitest::Test
     ScreenSize.create({ resolution_height: "1920", resolution_width: "1280" })
     ScreenSize.create({ resolution_height: "1600", resolution_width: "800" })
 
-    assert_equal ["1600 x 800", "1920 x 1280", "1280 x 800"], ScreenSize.all_screen_sizes
+    assert_equal "1600 x 800, 1920 x 1280, 1280 x 800", ScreenSize.all_screen_sizes
   end
 
 end

--- a/test/models/url_test.rb
+++ b/test/models/url_test.rb
@@ -20,7 +20,7 @@ class UrlTest < Minitest::Test
     url3 = Url.create({address: "http://www.nyt.com"})
     url4 = Url.create({address: "http://www.nyt.com"})
     url5 = Url.create({address: "http://www.nyt.com"})
-    assert_equal ["http://www.nyt.com", "http://www.google.com"], Url.list_urls_by_frequency
+    assert_equal "http://www.nyt.com, http://www.google.com", Url.list_urls_by_frequency
   end
 
   def test_can_find_max_response_time_for_specific_url

--- a/test/models/user_agent_info_test.rb
+++ b/test/models/user_agent_info_test.rb
@@ -34,7 +34,7 @@ class UserAgentInfoTest < Minitest::Test
     agent2 = UserAgentInfo.create({ browser: "Opera!", version: "Version!", platform: "Platform!", os: "Windows 10"})
     agent3 = UserAgentInfo.create({ browser: "Dolphin!", version: "Version!", platform: "Platform!", os: "Windows 10"})
     agent4 = UserAgentInfo.create({ browser: "Netscape!", version: "Version!", platform: "Platform!", os: "Windows 10"})
-    assert_equal ["Chrome!", "Dolphin!", "Netscape!", "Opera!"], UserAgentInfo.all_browsers
+    assert_equal "Chrome!, Dolphin!, Netscape!, Opera!", UserAgentInfo.all_browsers
   end
 
   def test_it_gives_list_of_all_oses
@@ -42,6 +42,6 @@ class UserAgentInfoTest < Minitest::Test
     agent2 = UserAgentInfo.create({ browser: "Opera!", version: "Version!", platform: "MacIntosh", os: "Mac OS X"})
     agent3 = UserAgentInfo.create({ browser: "Dolphin!", version: "Version!", platform: "Windows", os: "Windows 8.1"})
     agent4 = UserAgentInfo.create({ browser: "Netscape!", version: "Version!", platform: "Platform!", os: "Windows 95"})
-    assert_equal ["Mac OS X", "Windows 10", "Windows 8.1", "Windows 95"], UserAgentInfo.all_oses
+    assert_equal "Mac OS X, Windows 10, Windows 8.1, Windows 95", UserAgentInfo.all_oses
   end
 end


### PR DESCRIPTION
We changed some model methods to output only strings instead of arrays of strings, so I updated the model tests to reflect those changes.
