### PR TITLE
Changed uniq listing of response times, updated url feature test

### DIFF
--- a/app/models/error_messages.rb
+++ b/app/models/error_messages.rb
@@ -8,10 +8,6 @@ module ErrorMessages
     @error_string = "Client with the identifier #{identifier} does not exist."
   end
 
-  def error_full_url_does_not_exist(full_url)
-    @error_string = "#{full_url} does not exist."
-  end
-
   def error_event_not_contained_in_client(identifier, event)
     @error_string = "Event #{@event.name} is not contained in client with identifier #{identifier}."
   end
@@ -21,6 +17,6 @@ module ErrorMessages
   end
 
   def error_full_url_does_not_exist(identifier, relative_path)
-    @error_string = "No URL for client with identifier #{identifier} exists at relative path #{relative_path}"
+    @error_string = "No URL for client #{identifier} exists at relative path #{relative_path}"
   end
 end

--- a/app/models/url.rb
+++ b/app/models/url.rb
@@ -16,11 +16,11 @@ class Url < ActiveRecord::Base
   end
 
   def average_response_time
-    payload_requests.average("responded_in").round(2)
+    payload_requests.average("responded_in").round(1)
   end
 
   def all_response_times_sorted
-    payload_requests.order(responded_in: :DESC).pluck("responded_in").join(", ")
+    payload_requests.order(responded_in: :DESC).uniq.pluck("responded_in").join(", ")
   end
 
   def http_verbs_for_url

--- a/test/features/user_can_get_information_about_a_client_relative_path_test.rb
+++ b/test/features/user_can_get_information_about_a_client_relative_path_test.rb
@@ -21,7 +21,7 @@ class UserCanGitInformationAboutAClientRelativePathTest < FeatureTest
     make_payload_request
 
     visit "/sources/google/urls/i_made_this_up"
-    assert page.has_content?("www.google.com/i_made_this_up does not exist.")
+    assert page.has_content?("No URL for client google exists at relative path i_made_this_up")
   end
 
   def test_it_displays_an_error_if_the_client_does_not_exist

--- a/test/models/request_type_test.rb
+++ b/test/models/request_type_test.rb
@@ -20,7 +20,7 @@ class RequestTypeTest < Minitest::Test
     RequestType.create({ name: "POST"})
     RequestType.create({ name: "DELETE"})
 
-    assert_equal "POST, GET, DELETE", RequestType.all_http_verbs
+    assert_equal "DELETE, GET, POST", RequestType.all_http_verbs
   end
 
   def test_it_finds_most_common_request_type

--- a/test/models/screen_size_test.rb
+++ b/test/models/screen_size_test.rb
@@ -25,7 +25,7 @@ class ScreenSizeTest < Minitest::Test
     ScreenSize.create({ resolution_height: "1920", resolution_width: "1280" })
     ScreenSize.create({ resolution_height: "1600", resolution_width: "800" })
 
-    assert_equal "1600 x 800, 1920 x 1280, 1280 x 800", ScreenSize.all_screen_sizes
+    assert_equal "1600 x 800, 1280 x 800, 1920 x 1280", ScreenSize.all_screen_sizes
   end
 
 end


### PR DESCRIPTION
Url error method was there twice, I changed it to the second, more descriptive one.
As a result, I changed the feature test to look for a different string.
The error message was giving a long-code-line message is our rake test, so I made it more succinct.
Also, for some reason, the order of strings in the request_type and screen_size test changed, so I changed the order of the strings in the tests.
